### PR TITLE
Fix bug for not being able to read user input when creating new layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if(PLAIN_KEYS)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic -Wno-deprecated-declarations -Wno-variadic-macros")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic -Wno-variadic-macros")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,6 @@ set(qjoypad_SOURCES
 	buttonw.cpp
 	event.cpp
 	flash.cpp
-	getkey.cpp
 	icon.cpp
 	joypad.cpp
 	joypadw.cpp
@@ -31,7 +30,6 @@ set(qjoypad_QOBJECT_HEADERS
 	button.h
 	buttonw.h
 	flash.h
-	getkey.h
 	icon.h
 	joypad.h
 	joypadw.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(qjoypad_SOURCES
 	joypadw.cpp
 	joyslider.cpp
 	keycode.cpp
+	keydialog.cpp
 	layout.cpp
 	layout_edit.cpp
 	main.cpp
@@ -36,6 +37,7 @@ set(qjoypad_QOBJECT_HEADERS
 	joypadw.h
 	joyslider.h
 	keycode.h
+	keydialog.hpp
 	layout_edit.h
 	layout.h
 	quickset.h)

--- a/src/keycode.cpp
+++ b/src/keycode.cpp
@@ -1,6 +1,7 @@
 #include <QX11Info>
 #include "keycode.h"
-#include "getkey.h"
+#include "keydialog.hpp"
+#include <X11/XKBlib.h>
 
 const QString ktos( int keycode )
 {
@@ -8,7 +9,7 @@ const QString ktos( int keycode )
 
     if (keycode == 0) return "[NO KEY]";
 
-    QString xname = XKeysymToString(XKeycodeToKeysym(QX11Info::display(), keycode,0));
+    QString xname = XKeysymToString( XkbKeycodeToKeysym( QX11Info::display(), keycode, 0, 0 ) );
 
 //this section of code converts standard X11 keynames into much nicer names
 //which are prettier, fit the dialogs better, and are more readily understandable.
@@ -90,7 +91,7 @@ KeyButton::KeyButton( QString name, int val, QWidget* parent, bool m, bool nowMo
 
 void KeyButton::onClick() {
     //when clicked, ask for a key!
-    int retValue = GetKey::getKey(buttonname, mouse, &mouseClicked, this->window());
+    int retValue = KeyDialog::getKey(buttonname, mouse, &mouseClicked, this->window());
     // -1 is a special value meaning that the window was simply
     // closed so we can ignore this
     if (retValue < 0) {

--- a/src/keydialog.cpp
+++ b/src/keydialog.cpp
@@ -1,0 +1,74 @@
+#include "keydialog.hpp"
+
+#include <QGuiApplication>
+#include <QPointer>
+
+KeyDialog::KeyDialog( const QString& button, bool m, QWidget* parent ) :
+QDialog( parent ),
+m_acceptMouse( m ),
+m_text( this ),
+m_isMouse( false ),
+m_value( 0 )
+{
+    setWindowTitle( "Choose a key" );
+    m_text.setText( QString( "Choose a new key %1for %2\n(Ctrl-X for no key)" ).
+            arg( m ? "or mouse button " : "" ).arg( button ) );
+    m_text.adjustSize();
+    setFixedSize( m_text.width() + 20, m_text.height() + 20 );
+    m_text.move( 10, 10 );
+}
+
+int KeyDialog::getKey( const QString& button, bool acceptMouse, bool* mouseOut, QWidget* parent ) {
+    bool isMouse = false;
+    quint32 value = 0;
+
+    QPointer<KeyDialog> dialog = new KeyDialog( button, acceptMouse, parent );
+    if ( dialog->exec() != QDialog::Accepted ) {
+        delete dialog;
+        return -1;
+    }
+    if ( !dialog ) {
+        return -1;
+    }
+
+    isMouse = dialog->m_isMouse;
+    value = dialog->m_value;
+    delete dialog;
+
+    if ( mouseOut ) {
+        *mouseOut = isMouse;
+    }
+    return value;
+}
+
+void KeyDialog::keyReleaseEvent( QKeyEvent* event ) {
+    if ( event->key() != Qt::Key_Control ) {
+        return;
+    }
+    m_value = event->nativeScanCode();
+    m_isMouse = false;
+    accept();
+}
+
+void KeyDialog::keyPressEvent( QKeyEvent* event ) {
+    if ( event->key() == Qt::Key_Control ) {
+        return;
+    }
+    if ( event->key() == Qt::Key_X && QGuiApplication::keyboardModifiers() == Qt::ControlModifier ) {
+        m_value = 0;
+    } else {
+        m_value = event->nativeScanCode();
+    }
+    m_isMouse = false;
+    accept();
+}
+
+void KeyDialog::mouseReleaseEvent( QMouseEvent* event ) {
+    if ( !m_acceptMouse ) {
+        return;
+    }
+    // TODO: correct Qt::MouseButton to XTst equivalent
+    m_value = event->button();
+    m_isMouse = true;
+    accept();
+}

--- a/src/keydialog.cpp
+++ b/src/keydialog.cpp
@@ -63,12 +63,20 @@ void KeyDialog::keyPressEvent( QKeyEvent* event ) {
     accept();
 }
 
+static quint32 qtMouseButtonToXButton( Qt::MouseButton button ) {
+    switch ( button ) {
+        case Qt::LeftButton: return 1;
+        case Qt::MiddleButton: return 2;
+        case Qt::RightButton: return 3;
+        default: return 0;
+    }
+}
+
 void KeyDialog::mouseReleaseEvent( QMouseEvent* event ) {
     if ( !m_acceptMouse ) {
         return;
     }
-    // TODO: correct Qt::MouseButton to XTst equivalent
-    m_value = event->button();
+    m_value = qtMouseButtonToXButton( event->button() );
     m_isMouse = true;
     accept();
 }

--- a/src/keydialog.hpp
+++ b/src/keydialog.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QDialog>
+#include <QString>
+#include <QLabel>
+#include <QKeyEvent>
+#include <QMouseEvent>
+
+class KeyDialog : public QDialog {
+    Q_OBJECT
+
+protected:
+    bool m_acceptMouse;
+    QLabel m_text;
+
+    bool m_isMouse;
+    quint32 m_value;
+
+    KeyDialog( const QString& button, bool m = false, QWidget* parent = 0 );
+    void keyPressEvent( QKeyEvent* );
+    void keyReleaseEvent( QKeyEvent* );
+    void mouseReleaseEvent( QMouseEvent* );
+
+public:
+    static int getKey( const QString& button, bool acceptMouse = false, bool* mousePressed = 0, QWidget* parent = 0 );
+
+};

--- a/src/quickset.cpp
+++ b/src/quickset.cpp
@@ -1,5 +1,5 @@
 #include "quickset.h"
-#include "getkey.h"
+#include "keydialog.hpp"
 
 //build the dialog
 QuickSet::QuickSet( JoyPad* jp, QWidget *parent)
@@ -31,7 +31,7 @@ void QuickSet::jsevent(const js_event &msg ) {
             //go into setting mode and request a key/mousebutton
             setting = true;
             bool isMouse = false;
-            int code = GetKey::getKey(button->getName(), true, &isMouse, this);
+            int code = KeyDialog::getKey(button->getName(), true, &isMouse, this);
             setting = false;
 
             if (code >= 0) {
@@ -49,7 +49,7 @@ void QuickSet::jsevent(const js_event &msg ) {
         //grab a keycode for that axis and that direction
         setting = true;
         bool isMouse = false;
-        int code = GetKey::getKey((msg.value >= 0 ? tr("%1, positive") : tr("%1, negative")).arg(axis->getName()), true, &isMouse, this);
+        int code = KeyDialog::getKey((msg.value >= 0 ? tr("%1, positive") : tr("%1, negative")).arg(axis->getName()), true, &isMouse, this);
         setting = false;
 
         //assign the key to the axis.


### PR DESCRIPTION
Right now it compiles because of -Wno-deprecated-declarations compiler parameter, but it didn't work.
Also QWidget::x11Event() didn't even fire when removed deprecated functions.

With the changes we can read user input for keyboard when creating new layout.