### PR TITLE
XF86AudioRaiseVolume button support

### DIFF
--- a/src/constant.h
+++ b/src/constant.h
@@ -17,7 +17,7 @@
 #define JOYMIN -32767
 
 //maximum number of defined keys
-#define MAXKEY 122
+#define MAXKEY 123
 
 //fastest the mouse can go. Completely arbitrary.
 #define MAXMOUSESPEED 5000


### PR DESCRIPTION
I have a PS3 bt keyboard, which has a lot of buttons that are actually joypad buttons, while I'm pressing Fn.

Long story short, I wanted to map two of them as volume+ and volume-. Turns out that the key codes are respectively 123 and 122, that I had to write manually on the `lyt` file. Without this modification, qjoypad didn't like the layout.

Anyway, I have no idea on the actual mapping for other keys, meaning that possibly there are other keys beyond the 123 limit. Feel free to do something smarter!