### PR TITLE
Increase the maximum key number 

### DIFF
--- a/src/constant.h
+++ b/src/constant.h
@@ -17,7 +17,7 @@
 #define JOYMIN -32767
 
 //maximum number of defined keys
-#define MAXKEY 123
+#define MAXKEY 255
 
 //fastest the mouse can go. Completely arbitrary.
 #define MAXMOUSESPEED 5000


### PR DESCRIPTION
With an increased maximum key number it is possible to simulate multimedia keys, e.g. XF86AudioRecord.