### PR TITLE
Add Snap package support:smiley:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build
 build-*
 CMakeLists.txt.user
+*.snap
+snap/snapcraft.yaml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 QJoyPad 4
 =========
 
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/qjoypad-ahimta)
+
 This is a fork of [QJoyPad](http://qjoypad.sourceforge.net/) with some small additional
 features, Qt 5 port and some bug/memory leak fixes. QJoyPad was originally developed by
 Nathan Gaylinn <wren42@users.sourceforge.net> and John Toman <virtuoussin13@users.sourceforge.net>.
@@ -121,7 +123,7 @@ changed.
    them somewhere else, you'll need to run cmake like this:
 
    `cmake .. -DDEVICE_DIR=/dev`
-   
+
    Do this if your joystick devices are `/dev/js0`, `/dev/js1`
    etc.
 
@@ -440,7 +442,7 @@ using QJoyPad for joystick support, you could create a text
 file called run-xgalaga with the following lines in it:
 
 	#!/bin/sh
-	
+
 	qjoypad "XGalaga" &
 	xgalaga++
 
@@ -536,7 +538,7 @@ compiled with the devdir setting pointing to the wrong place.
 That option had to be set at compile time, and to change it
 you must recompile (see [Installation](#installation)); however,
 if you don't want to bother with that, you can specify the
-location of your devices as an argument. Using the command 
+location of your devices as an argument. Using the command
 `qjoypad --device /dev/input`, for example, will start QJoyPad
 and tell it to look for joysticks in `/dev/input/js0`,
 `/dev/input/js1`, etc.
@@ -691,7 +693,7 @@ is used to automatically update the joypad list. If automatically
 updating of the joypad list still does not work compile with
 `-DCMAKE_BUILD_TYPE=Debug` and post the output on the [GitHub
 bug tracker](https://github.com/panzi/qjoypad/issues).
-	
+
 You can force QJoyPad to rescan your joypads at any time using the
 menu or by running `qjoypad --update`.
 

--- a/scripts/_helpers.sh
+++ b/scripts/_helpers.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+DebugName="qjoypad-debug"
+ReleaseName="qjoypad-release"
+StoreName="qjoypad-ahimta"
+
+get_snap_name() {
+  local Variant=$1
+
+  case  $Variant  in
+  "debug")
+    echo $DebugName
+    return 0
+    ;;
+  "release")
+    echo $ReleaseName
+    return 0
+    ;;
+  "store")
+    echo $StoreName
+    return 0
+    ;;
+  *)
+    print_variant_error_help_and_exit "$Variant"
+    exit 1
+    ;;
+  esac
+}
+
+print_variant_error_help_and_exit() {
+  local Variant=$1
+
+  echo "Error: Incorrect or missing variant parameter of '$Variant'." 1>&2
+  echo "<variant> must be one of the following:" 1>&2
+  echo "- 'debug': For general local development and testing. And will result in '$DebugName' after installing the resulting snap." 1>&2
+  echo "- 'release': For testing the closest possible package to the Snap store. And will result in '$ReleaseName' after installing the resulting snap." 1>&2
+  echo "- 'store': For releasing the package to the Snap store. And will result in '$StoreName' after installing the resulting snap." 1>&2
+
+  return 0
+}

--- a/scripts/install-snap.sh
+++ b/scripts/install-snap.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# This is a wrapper to install a snap and set appropriate
+# connections/permissions.
+# Usage: ./scripts/install-snap.sh <variant> <snap-file-path>
+
+# shellcheck disable=SC1091
+source ./scripts/_helpers.sh
+
+Variant=$1
+SnapFilePath=$2
+
+SnapName=$(get_snap_name "$Variant")
+
+if test $? -ne 0; then
+  echo "Usage: ./scripts/install-snap.sh <variant> <snap-file-path>"
+  exit $?
+fi
+
+sudo snap install --dangerous "$SnapFilePath" &&\
+  sudo snap connect "$SnapName:joystick" :joystick

--- a/scripts/snapcraft.sh
+++ b/scripts/snapcraft.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# This is a wrapper for `snapcraft` to make it easier to develop, test, and
+# release without any conflict with the local installation.
+# Usage: ./scripts/snapcraft.sh <variant> [snpacraft-arg...]
+
+# shellcheck disable=SC1091
+source ./scripts/_helpers.sh
+
+get_version_part() {
+  local PartName=$1
+
+  local CMakeListsFile=CMakeLists.txt
+
+  local PartLine
+  local PartName
+  PartLine=$(grep "$PartName" $CMakeListsFile)
+  PartName=$(echo "$PartLine" | sed --regexp-extended 's#^.*([0-9]+).*$#\1#')
+
+  echo "$PartName"
+  return 0
+}
+
+Variant=$1
+Name=$(get_snap_name "$Variant")
+
+case  $Variant  in
+"debug")
+  Title="QJoyPad (Debug)"
+  Grade="devel"
+  ;;
+"release")
+  Title="QJoyPad (Release)"
+  Grade="stable"
+  ;;
+"store")
+  Title="QJoyPad"
+  Grade="stable"
+  ;;
+"help"|"--help"|*)
+  echo "Usage: ./scripts/snapcraft.sh <variant> [snpacraft-arg...]"
+  exit 0
+  ;;
+esac
+
+AllArgs=("$@")
+RestArgs=("${AllArgs[@]:1}")
+SnapcraftArgs=("${RestArgs[@]}")
+
+SnapcraftFile=snap/snapcraft.yaml
+SnapcraftTemplate=snap/local/snapcraft.scaffold.yaml
+
+VersionMajor=$(get_version_part QJOYPAD_MAJOR)
+VersionMinor=$(get_version_part QJOYPAD_MINOR)
+VersionPatch=$(get_version_part QJOYPAD_PATCH)
+VersionGit=$(git rev-parse --short HEAD)
+Version="$VersionMajor.$VersionMinor.$VersionPatch+git-$VersionGit"
+
+rm --force ./*.snap
+rm --force $SnapcraftFile
+
+cp $SnapcraftTemplate $SnapcraftFile
+
+GenerationNote="# NOTE: This file is generated using 'scripts/snapcraft.sh'."
+sed --in-place "1s|^|$GenerationNote\n|" $SnapcraftFile
+
+sed --in-place "s|@@TITLE@@|$Title|g" $SnapcraftFile
+sed --in-place "s|@@NAME@@|$Name|g" $SnapcraftFile
+sed --in-place "s|@@GRADE@@|$Grade|g" $SnapcraftFile
+sed --in-place "s|@@VERSION@@|$Version|g" $SnapcraftFile
+
+snapcraft "${SnapcraftArgs[@]}"

--- a/scripts/uninstall-snap.sh
+++ b/scripts/uninstall-snap.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# This is a wrapper to uninstall a snap.
+# Usage: ./scripts/uninstall-snap.sh <variant>
+
+# shellcheck disable=SC1091
+source ./scripts/_helpers.sh
+
+Variant=$1
+
+SnapName=$(get_snap_name "$Variant")
+
+if test $? -ne 0; then
+  exit $?
+fi
+
+sudo snap remove --purge "$SnapName"

--- a/snap/local/snapcraft.scaffold.yaml
+++ b/snap/local/snapcraft.scaffold.yaml
@@ -1,0 +1,151 @@
+title: @@TITLE@@
+name: @@NAME@@ # you probably want to 'snapcraft register <name>'
+base: core18 # the base snap is the execution environment for this snap
+summary: Joypad to Keyboard/Mouse Mapper # 79 char summary
+description: |
+  QJoyPad is a convenient little program with a Qt interface that converts
+  movement and button presses on a gamepad or joystick into key presses, mouse
+  clicks, and mouse movement in XWindows. It should work on almost every Linux
+  system and with any Linux-supported gaming device.
+
+confinement: strict
+grade: @@GRADE@@ # must be 'stable' to release into candidate/stable channels
+icon: icons/gamepad4-64x64.png
+license: GPL-2.0
+version: @@VERSION@@ # just for humans, typically '1.2+git' or '1.3.2'
+
+architectures:
+- build-on: [amd64]
+  run-on: [amd64]
+
+plugs:
+  # Support for common GTK themes
+  # https://forum.snapcraft.io/t/how-to-use-the-system-gtk-theme-via-the-gtk-common-themes-snap/6235
+  gsettings:
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+
+# HACK: `layout` is needed because QJoyPad uses absolute paths internally that
+# are determined at build/compile time and are tied to installation prefix
+# (`CMAKE_INSTALL_PREFIX`). It would be best if the app no longer uses absolute
+# paths and `layout` is not needed anymore:sweat_smile:.
+layout:
+  /usr/share/icons/hicolor/24x24/apps:
+    bind: $SNAP/usr/share/icons/hicolor/24x24/apps
+  /usr/share/icons/hicolor/64x64/apps:
+    bind: $SNAP/usr/share/icons/hicolor/64x64/apps
+  /usr/share/qjoypad/translations:
+    bind: $SNAP/usr/share/qjoypad/translations
+
+apps:
+  @@NAME@@:
+    adapter: full
+    command: usr/bin/qjoypad
+    command-chain: [bin/desktop-launch]
+    desktop: usr/share/applications/qjoypad.desktop
+    environment:
+      # Use GTK3 cursor theme, icon theme and open/save file dialogs.
+      QT_QPA_PLATFORMTHEME: gtk3
+    plugs:
+    - desktop
+    - joystick
+    - opengl
+    - unity7
+
+parts:
+  qjoypad:
+    after: [desktop-qt5]
+    plugin: nil # See 'snapcraft plugins'
+    source: .
+    build-packages:
+    - cmake
+    - g++
+    - pkg-config
+    - libqt5x11extras5-dev
+    - libudev-dev
+    - libxtst-dev
+    - qttools5-dev
+    build-environment:
+    - ICON_RELATIVE_PATH: share/icons/hicolor/64x64/apps/qjoypad.png
+    - RUNTIME_INSTALL_PREFIX: /usr
+    override-build: |
+      BUILD_INSTALL_PREFIX=$SNAPCRAFT_PART_INSTALL$RUNTIME_INSTALL_PREFIX
+      RUNTIME_ICON_PATH=$RUNTIME_INSTALL_PREFIX/$ICON_RELATIVE_PATH
+
+      sed \
+        --in-place \
+        "s#Name=.*#Name=@@TITLE@@#" \
+        qjoypad.desktop
+
+      sed \
+        --in-place \
+        "s#Exec=.*#Exec=@@NAME@@#" \
+        qjoypad.desktop
+
+      sed \
+        --in-place \
+        "s#Icon=.*#Icon=$RUNTIME_ICON_PATH#" \
+        qjoypad.desktop
+
+      sed \
+        --in-place \
+        "s#@CMAKE_INSTALL_PREFIX@#$RUNTIME_INSTALL_PREFIX#g" \
+        src/config.h.in
+
+      mkdir --parents build
+      rm --recursive --force build/*
+      cd build
+
+      cmake \
+        .. \
+        -DCMAKE_INSTALL_PREFIX=$BUILD_INSTALL_PREFIX \
+        -DCMAKE_BUILD_TYPE=Release
+
+      make --jobs `nproc`
+      make install
+
+      snapcraftctl build
+    stage-packages:
+    - libqt5x11extras5
+    - libxtst6
+  # NOTE: `desktop-qt5` is copied from
+  # https://github.com/ubuntu/snapcraft-desktop-helpers/blob/4c0ff0ae186e3e7791c5878e87b4115b89e9de15/snapcraft.yaml#L242
+  # as instructed by https://forum.snapcraft.io/t/desktop-app-support-qt5/11703
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: qt
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+    - build-essential
+    - qtbase5-dev
+    - dpkg-dev
+    stage-packages:
+    - libxkbcommon0
+    - ttf-ubuntu-font-family
+    - dmz-cursor-theme
+    - light-themes
+    - adwaita-icon-theme
+    - gnome-themes-standard
+    - shared-mime-info
+    - libqt5gui5
+    - libgdk-pixbuf2.0-0
+    - libqt5svg5 # for loading icon themes which are svg
+    - try: [appmenu-qt5] # not available on core18
+    - locales-all
+    - xdg-user-dirs
+    - fcitx-frontend-qt5
+  qt5-gtk-platform:
+    after: [desktop-qt5]
+    plugin: nil
+    stage-packages: [qt5-gtk-platformtheme]


### PR DESCRIPTION
Releasable at the moment as `qjoypad-ahimta` because `qjoypad` is
already reserved in the Snap store:sweat_smile:.

Some BASH scripts are added to make it easier develop, test, and release
using the Snap:smiley:.

You can see the listing on the Snap store at https://snapcraft.io/qjoypad-ahimta