### PR TITLE
Fix for #46 : Positive mapping of axis not released when one of the bindings is set to a mouse button

### DIFF
--- a/src/axis.cpp
+++ b/src/axis.cpp
@@ -12,6 +12,7 @@ Axis::Axis( int i, QObject *parent ) : QObject(parent) {
     index = i;
     isOn = false;
     isDown = false;
+    useMouse = false;
     state = 0;
     interpretation = ZeroOne;
     gradient = false;
@@ -378,7 +379,7 @@ void Axis::move( bool press ) {
         //dialog being open and blocking events from happening.
         if (isDown == press) return;
         isDown = press;
-        bool useMouse = (state > 0)?puseMouse:nuseMouse;
+        useMouse = (state == 0 )? useMouse: (state > 0) ?puseMouse:nuseMouse;
         if (press) {
             e.type = useMouse ? FakeEvent::MouseDown : FakeEvent::KeyDown;
             downkey = (state > 0)?pkeycode:nkeycode;

--- a/src/axis.h
+++ b/src/axis.h
@@ -72,6 +72,8 @@ class Axis : public QObject {
 		virtual void move( bool press );
 		//is a key currently depressed?
 		bool isDown;
+		//is a mouse button currently in use?
+		bool useMouse;
 
 		//variables for calculating quadratic used for gradient mouse axes
 		float inverseRange;


### PR DESCRIPTION
This fixes #46 by keeping memory of if the last axis input was a mouse button or not.