### PR TITLE
Implementation of KeyboardAndMouse mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,20 @@ has just one and treats the way the axis moves differently. In
 one of the throttle modes, the axis will be considered
 centered when it is all the way to one direction or the other.
 
+#### KeyboardAndMouse mode
+
+This mode works by merging functions of mouse control mode
+(any subtype) and keyboard events control. The only difference
+is that virtual keypresses are executed on reaching the red
+marker/tab on axis (to keep compatibility with mouse movement
+starting on the blue marker, and reaching max speed on the red
+marker/tab).
+
+The idea is that in some applications, you can use mouse emulation
+for precise aiming, while further on the axis (or even at extreme
+positions) the button presses are executed, for any additional
+function one might require.
+
 ### Configuring buttons
 
 ![BUtton Edit](http://i.imgur.com/Grwrunu.png)

--- a/src/axis.cpp
+++ b/src/axis.cpp
@@ -149,17 +149,11 @@ bool Axis::read(QTextStream &stream) {
         else if (word == "keyboardandmousevert") {
             mode = KeyboardAndMouseVert;
         }
-        else if (word == "keyboardandmouseposhor") {
-            mode = KeyboardAndMousePosHor;
+        else if (word == "keyboardandmousehorrev") {
+            mode = KeyboardAndMouseHorRev;
         }
-        else if (word == "keyboardandmouseneghor") {
-            mode = KeyboardAndMouseNegHor;
-        }
-        else if (word == "keyboardandmouseposvert") {
-            mode = KeyboardAndMousePosVert;
-        }
-        else if (word == "keyboardandmousenegvert") {
-            mode = KeyboardAndMouseNegVert;
+        else if (word == "keyboardandmousevertrev") {
+            mode = KeyboardAndMouseVertRev;
         }
         else {
             // Nieznane słowo - zamiast zwracać false, tylko ignoruj i kontynuuj
@@ -205,10 +199,8 @@ void Axis::write(QTextStream &stream) {
     if (mode == Keyboard ||
         mode == KeyboardAndMouseHor ||
         mode == KeyboardAndMouseVert ||
-        mode == KeyboardAndMousePosHor ||
-        mode == KeyboardAndMouseNegHor ||
-        mode == KeyboardAndMousePosVert ||
-        mode == KeyboardAndMouseNegVert) {
+        mode == KeyboardAndMouseHorRev ||
+        mode == KeyboardAndMouseVertRev) {
         
         stream << ", " 
                << (puseMouse ? "+mouse " : "+key ") << pkeycode << ", "
@@ -238,17 +230,11 @@ void Axis::write(QTextStream &stream) {
         case KeyboardAndMouseVert:
             stream << ", keyboardandmousevert";
             break;
-        case KeyboardAndMousePosHor:
-            stream << ", keyboardandmouseposhor";
+        case KeyboardAndMouseHorRev:
+            stream << ", keyboardandmousehorrev";
             break;
-        case KeyboardAndMouseNegHor:
-            stream << ", keyboardandmouseneghor";
-            break;
-        case KeyboardAndMousePosVert:
-            stream << ", keyboardandmouseposvert";
-            break;
-        case KeyboardAndMouseNegVert:
-            stream << ", keyboardandmousenegvert";
+        case KeyboardAndMouseVertRev:
+            stream << ", keyboardandmousevertrev";
             break;
     }
 
@@ -425,10 +411,8 @@ void Axis::move(bool press) {
         mode == Keyboard ||
         mode == KeyboardAndMouseHor ||
         mode == KeyboardAndMouseVert ||
-        mode == KeyboardAndMousePosHor ||
-        mode == KeyboardAndMouseNegHor ||
-        mode == KeyboardAndMousePosVert ||
-        mode == KeyboardAndMouseNegVert
+        mode == KeyboardAndMouseHorRev ||
+        mode == KeyboardAndMouseVertRev
     ) {
         // obsługa klawiszy:
         if (isDown == press && mode == Keyboard) return; // zapobiega powtórzeniom
@@ -528,18 +512,19 @@ void Axis::move(bool press) {
                 case MouseNegHor:
                     e.move.x = -dist;
                     break;
-                case KeyboardAndMouseHor:
-                case KeyboardAndMousePosHor:
-                case KeyboardAndMouseNegHor:
-                    // poziomy ruch myszy (kierunek uwzględniony w dist)
-                    e.move.x = dist;
-                    break;
-                case KeyboardAndMouseVert:
-                case KeyboardAndMousePosVert:
-                case KeyboardAndMouseNegVert:
-                    // pionowy ruch myszy
-                    e.move.y = dist;
-                    break;
+                    case KeyboardAndMouseHor:
+                        e.move.x = dist;
+                        break;
+                    case KeyboardAndMouseHorRev:
+                        e.move.x = -dist;
+                        break;
+                    case KeyboardAndMouseVert:
+                        e.move.y = dist;
+                        break;
+                    case KeyboardAndMouseVertRev:
+                        e.move.y = -dist;
+                        break;
+
                 default:
                     break;
             }

--- a/src/axis.h
+++ b/src/axis.h
@@ -20,15 +20,15 @@ class Axis : public QObject {
 public:
     enum Interpretation { ZeroOne, Gradient, AbsolutePos };
 
-    // Dodane nowe tryby do rozszerzonej obsługi osi:
+    // Added new modes for extended axis handling:
     enum Mode {
         Keyboard,
         MousePosVert,
         MouseNegVert,
         MousePosHor,
         MouseNegHor,
-        KeyboardAndMouseHor,     // nowy tryb poziomego ruchu myszy + klawisze
-        KeyboardAndMouseVert,    // nowy tryb pionowego ruchu myszy + klawisze
+        KeyboardAndMouseHor,     // new mode: horizontal mouse movement + keys
+        KeyboardAndMouseVert,    // new mode: vertical mouse movement + keys
         KeyboardAndMouseHorRev,
         KeyboardAndMouseVertRev,
     };

--- a/src/axis.h
+++ b/src/axis.h
@@ -1,7 +1,6 @@
 #ifndef QJOYPAD_AXIS_H
 #define QJOYPAD_AXIS_H
 
-//abs()
 #include <stdlib.h>
 #include <math.h>
 
@@ -12,101 +11,86 @@
 #include "constant.h"
 #include "error.h"
 
-//default and arbitrary values for dZone and xZone
 #define DZONE 3000
 #define XZONE 30000
 
-
-//represents one joystick axis
 class Axis : public QObject {
     Q_OBJECT
 
-    //each axis can create a key press or move the mouse in one of four directions.
+public:
     enum Interpretation { ZeroOne, Gradient, AbsolutePos };
-    enum Mode {Keyboard, MousePosVert, MouseNegVert, MousePosHor, MouseNegHor};
-    enum TransferCurve {Linear, Quadratic, Cubic, QuadraticExtreme,
-                        PowerFunction};
 
-    //so AxisEdit can manipulate fields directly.
-	friend class AxisEdit;
-	public:
-		Axis( int i, QObject *parent = 0 );
-		~Axis();
-		//read axis settings from a stream
-		bool read( QTextStream &stream );
-		//write axis settings to a stream
-		void write( QTextStream &stream );
-		//releases any pushed buttons and returns to a neutral state
-		void release();
-		//pass a message from the joystick device to this axis object
-		void jsevent( int value );
-		//revert to default settings
-		void toDefault();
-		//True iff currently at defaults
-		bool isDefault();
-		QString getName();
-		//true iff the given value is in the dead zone for this axis.
-		bool inDeadZone( int val );
-		//a descriptive string used as a label for the button representing this axis
-		QString status();
-		//set the key code for this axis. Used by quickset.
-		void setKey(bool positive, int value);
-		void setKey(bool useMouse, bool positive, int value);
-		//happens every MSEC milliseconds (constant.h)
-		//uses tick to decide if key events should be generated
-		void timerTick( int tick );
-		//recalculates the gradient curve. This should be run every time
-		//maxSpeed, xZone, or dZone are changed.
-		void adjustGradient();
-        int axisIndex() const { return index; }
-	protected:
-        int tick;
-        //This axis is logically depressed (positive or negative)
-		//if the axis is gradient, this is true even if it is not
-		//currently generating a keypress at the instant.
-		bool isOn;
-        //the index of this axis on the joystick
-		int index;
-		//actually sends key events. Press is true iff the key
-		//is to be depressed as opposed to released.
-		virtual void move( bool press );
-		//is a key currently depressed?
-		bool isDown;
-		//is a mouse button currently in use?
-		bool useMouse;
+    // Dodane nowe tryby do rozszerzonej obsługi osi:
+    enum Mode {
+        Keyboard,
+        MousePosVert,
+        MouseNegVert,
+        MousePosHor,
+        MouseNegHor,
+        KeyboardAndMouseHor,     // nowy tryb poziomego ruchu myszy + klawisze
+        KeyboardAndMouseVert,    // nowy tryb pionowego ruchu myszy + klawisze
+        KeyboardAndMousePosHor,  // nowy tryb ruch myszy poziomy + klawisze + kierunek +
+        KeyboardAndMouseNegHor,  // nowy tryb ruch myszy poziomy + klawisze + kierunek -
+        KeyboardAndMousePosVert, // nowy tryb ruch myszy pionowy + klawisze + kierunek +
+        KeyboardAndMouseNegVert  // nowy tryb ruch myszy pionowy + klawisze + kierunek -
+    };
 
-		//variables for calculating quadratic used for gradient mouse axes
-		float inverseRange;
- 
- 		//actual axis settings:
- 		Interpretation interpretation;
- 		bool gradient;
- 		bool absolute;
- 		int maxSpeed; //0..MAXMOUSESPEED
-		unsigned int transferCurve;
-		float sensitivity;
- 		int throttle; //-1 (nkey), 0 (no throttle), 1 (pkey)
- 		int dZone;//-32767 .. 32767
- 		int xZone;//-32767 .. 32767
-		double sumDist;
-		Mode mode;
-		//positive keycode
-		int pkeycode;
-		//negative keycode
-		int nkeycode;
-		bool puseMouse;
-		bool nuseMouse;
-		//the key that is currently pressed
-		int downkey;
-		//the position of the axis, as from jsevent
-		int state;
-		//how long a key should stay down when in gradient mode
-		//note, the key is still clicked at the same pace no matter what,
-		//this just decides how long it stays down each cycle.
-		int duration;
-        QTimer timer;
-    public slots:
-        void timerCalled();
+    enum TransferCurve { Linear, Quadratic, Cubic, QuadraticExtreme, PowerFunction };
+
+    friend class AxisEdit;
+
+    Axis(int i, QObject *parent = 0);
+    ~Axis();
+
+    bool read(QTextStream &stream);
+    void write(QTextStream &stream);
+    void release();
+    void jsevent(int value);
+    void toDefault();
+    bool isDefault();
+    QString getName();
+    bool inDeadZone(int val);
+    QString status();
+
+    void setKey(bool positive, int value);
+    void setKey(bool useMouse, bool positive, int value);
+
+    void timerTick(int tick);
+    void adjustGradient();
+    int axisIndex() const { return index; }
+
+protected:
+    int tick;
+    bool isOn;
+    int index;
+    virtual void move(bool press);
+    bool isDown;
+    bool useMouse;
+
+    float inverseRange;
+
+    Interpretation interpretation;
+    bool gradient;
+    bool absolute;
+    int maxSpeed;
+    unsigned int transferCurve;
+    float sensitivity;
+    int throttle;
+    int dZone;
+    int xZone;
+    double sumDist;
+    Mode mode;
+    int pkeycode;
+    int nkeycode;
+    bool puseMouse;
+    bool nuseMouse;
+    int downkey;
+    int state;
+    int duration;
+    QTimer timer;
+
+protected slots:
+    void timerCalled();
 };
 
 #endif

--- a/src/axis.h
+++ b/src/axis.h
@@ -29,10 +29,8 @@ public:
         MouseNegHor,
         KeyboardAndMouseHor,     // nowy tryb poziomego ruchu myszy + klawisze
         KeyboardAndMouseVert,    // nowy tryb pionowego ruchu myszy + klawisze
-        KeyboardAndMousePosHor,  // nowy tryb ruch myszy poziomy + klawisze + kierunek +
-        KeyboardAndMouseNegHor,  // nowy tryb ruch myszy poziomy + klawisze + kierunek -
-        KeyboardAndMousePosVert, // nowy tryb ruch myszy pionowy + klawisze + kierunek +
-        KeyboardAndMouseNegVert  // nowy tryb ruch myszy pionowy + klawisze + kierunek -
+        KeyboardAndMouseHorRev,
+        KeyboardAndMouseVertRev,
     };
 
     enum TransferCurve { Linear, Quadratic, Cubic, QuadraticExtreme, PowerFunction };

--- a/src/axis_edit.cpp
+++ b/src/axis_edit.cpp
@@ -3,7 +3,6 @@
 
 AxisEdit::AxisEdit( Axis* ax )
         :QDialog() {
-    //build the dialog, display current axis settings  :)
     axis = ax;
     setWindowTitle("Set " + axis->getName());
     setWindowIcon(QPixmap(QJOYPAD_ICON24));
@@ -31,13 +30,10 @@ AxisEdit::AxisEdit( Axis* ax )
     cmbMode->insertItem((int) Axis::MouseNegVert, tr("Mouse (Vert. Rev.)"), Qt::DisplayRole);
     cmbMode->insertItem((int) Axis::MousePosHor, tr("Mouse (Hor.)"), Qt::DisplayRole);
     cmbMode->insertItem((int) Axis::MouseNegHor, tr("Mouse (Hor. Rev.)"), Qt::DisplayRole);
-    // Dodane nowe tryby Keyboard + Mouse
     cmbMode->insertItem((int) Axis::KeyboardAndMouseHor, tr("Keyboard + Mouse (Hor.)"), Qt::DisplayRole);
+    cmbMode->insertItem((int) Axis::KeyboardAndMouseHorRev, tr("Keyboard + Mouse (Hor. Rev.)"), Qt::DisplayRole);
     cmbMode->insertItem((int) Axis::KeyboardAndMouseVert, tr("Keyboard + Mouse (Vert.)"), Qt::DisplayRole);
-    cmbMode->insertItem((int) Axis::KeyboardAndMousePosHor, tr("Keyboard + Mouse (Hor. Pos)"), Qt::DisplayRole);
-    cmbMode->insertItem((int) Axis::KeyboardAndMouseNegHor, tr("Keyboard + Mouse (Hor. Neg)"), Qt::DisplayRole);
-    cmbMode->insertItem((int) Axis::KeyboardAndMousePosVert, tr("Keyboard + Mouse (Vert. Pos)"), Qt::DisplayRole);
-    cmbMode->insertItem((int) Axis::KeyboardAndMouseNegVert, tr("Keyboard + Mouse (Vert. Neg)"), Qt::DisplayRole);
+    cmbMode->insertItem((int) Axis::KeyboardAndMouseVertRev, tr("Keyboard + Mouse (Vert. Rev.)"), Qt::DisplayRole);
 
     cmbMode->setCurrentIndex( axis->mode );
     connect(cmbMode, SIGNAL(activated(int)), this, SLOT( modeChanged( int )));
@@ -146,11 +142,9 @@ void AxisEdit::modeChanged( int index ) {
             keyBox->setEnabled(true);
             break;
         case Axis::KeyboardAndMouseHor:
+        case Axis::KeyboardAndMouseHorRev:
         case Axis::KeyboardAndMouseVert:
-        case Axis::KeyboardAndMousePosHor:
-        case Axis::KeyboardAndMouseNegHor:
-        case Axis::KeyboardAndMousePosVert:
-        case Axis::KeyboardAndMouseNegVert:
+        case Axis::KeyboardAndMouseVertRev:
             mouseBox->setEnabled(true);
             keyBox->setEnabled(true);
             if ((Axis::Interpretation)chkGradient->currentIndex() != Axis::ZeroOne) {

--- a/src/axis_edit.cpp
+++ b/src/axis_edit.cpp
@@ -108,6 +108,7 @@ AxisEdit::AxisEdit( Axis* ax )
     connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
     v->addWidget(buttonBox);
 
+    // Initialize dialog controls to current axis state
     gradientChanged( axis->interpretation );
     modeChanged( axis->mode );
     transferCurveChanged( axis->transferCurve );
@@ -116,11 +117,11 @@ AxisEdit::AxisEdit( Axis* ax )
 
 void AxisEdit::show() {
     QDialog::show();
-    setFixedSize(size());
+    setFixedSize(size());  // Fix dialog size to prevent resizing
 }
 
 void AxisEdit::setState( int val ) {
-    slider->setValue( val );
+    slider->setValue( val );  // Update slider position/value
 }
 
 void AxisEdit::gradientChanged( int index ) {

--- a/src/axis_edit.h
+++ b/src/axis_edit.h
@@ -1,7 +1,8 @@
 #ifndef QJOYPAD_AXIS_EDIT_H
 #define QJOYPAD_AXIS_EDIT_H
-//to refer to the axis we're editing
-//for building up the dialog we need
+
+// This header defines the AxisEdit dialog for editing joystick axis settings.
+
 #include "axis.h"
 #include <QComboBox>
 #include <QSpinBox>
@@ -9,37 +10,68 @@
 #include <QDoubleSpinBox>
 #include <QLabel>
 #include <QDialogButtonBox>
-//for my home-brewed widgets
+#include <QFrame>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+
+// Custom widgets for key selection and slider
 #include "joyslider.h"
 #include "keycode.h"
 
 class AxisEdit : public QDialog {
-	Q_OBJECT
-	public:
-		AxisEdit(Axis* ax);
-		//show the dialog (modal)
-		void show();
-		//set the current state of the axis (adjusts the JoySlider for real time
-		//notification of the state to the user)
-		void setState( int val );
-	protected slots:
-		//slots for GUI events
-		void gradientChanged( int index );
-		void modeChanged( int index );
-		void transferCurveChanged( int index );
-		void throttleChanged( int index );
-		void accept();
-	protected:
-		//the associated Axis that needs to be set.
-		Axis *axis;
-		//the important parts of the dialog:
-		QComboBox *chkGradient, *cmbMode, *cmbThrottle, *cmbTransferCurve;
-		QFrame *mouseBox, *keyBox;
-		QSpinBox *spinSpeed;
-		QLabel *lblSensitivity;
-		QDoubleSpinBox *spinSensitivity;
-		KeyButton *btnNeg, *btnPos;
-		JoySlider *slider;
+    Q_OBJECT
+public:
+    // Constructor takes a pointer to the Axis being edited
+    AxisEdit(Axis* ax);
+
+    // Show the dialog (modal)
+    void show();
+
+    // Update the slider state to reflect current axis state
+    void setState(int val);
+
+protected slots:
+    // Slot called when gradient mode selection changes
+    void gradientChanged(int index);
+
+    // Slot called when axis mode selection changes
+    void modeChanged(int index);
+
+    // Slot called when transfer curve selection changes
+    void transferCurveChanged(int index);
+
+    // Slot called when throttle selection changes
+    void throttleChanged(int index);
+
+    // Slot called when the user accepts the dialog
+    void accept();
+
+protected:
+    Axis* axis;               // The Axis being edited
+
+    // Combo box for choosing interpretation mode (ZeroOne, Gradient, Absolute)
+    QComboBox* chkGradient;
+
+    // Combo box for choosing axis mode (Keyboard, Mouse directions, KeyboardAndMouse)
+    QComboBox* cmbMode;
+
+    // Combo box for choosing throttle mode
+    QComboBox* cmbThrottle;
+
+    // Combo box for choosing mouse transfer curve
+    QComboBox* cmbTransferCurve;
+
+    QFrame* mouseBox;         // Frame holding mouse-related controls
+    QFrame* keyBox;           // Frame holding keyboard-related controls
+
+    QSpinBox* spinSpeed;      // Mouse speed setting
+    QLabel* lblSensitivity;   // Label for mouse sensitivity
+    QDoubleSpinBox* spinSensitivity; // Mouse sensitivity setting
+
+    KeyButton* btnNeg;        // Button for negative key/mouse selection
+    KeyButton* btnPos;        // Button for positive key/mouse selection
+
+    JoySlider* slider;        // Custom slider for dead zone and extreme zone
 };
 
 #endif


### PR DESCRIPTION
This pull requests implements KeyboardAndMouse mode - allowing to use *both* mouse control and keyboard press execution at same axis, at same time.

The changes incorporate full support for config files (profiles) including backward compatibility, additionally providing minor cleanup of the way those are saved (eliminating some breakage related to unexpected or unknown keys/flags in the original). It also keeps original functionality of QJoyPad4 untouched.

This fixes https://github.com/panzi/qjoypad/issues/54#issue-1252067742

In case of any issues encountered, I can maintain fixes for those changes for reasonably foreseeable future (few years at minimum).